### PR TITLE
Draft release notes on push to master

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,12 @@
+name: Release Drafter
+on:
+  push:
+    branches:
+      - master
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v7.7.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
plexus-i18n was the only repository in the org without this workflow, so it was the only one whose releases had no draft waiting on the releases page.

Copied verbatim from plexus-velocity. With no `config-name` the action resolves `.github/release-drafter.yml`, which this repository does not carry, so it falls back to the shared config in codehaus-plexus/.github — the same path every other single-line repo takes.

*This change was created with AI assistance.*