### PR TITLE
Bump the plexus dependencies released today

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-testing</artifactId>
-      <version>2.1.0</version>
+      <version>2.2.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
plexus-testing 2.1.0 to 2.2.0. 

Raised by hand rather than waiting for dependabot, so the pins are current before this project's own release is cut.

Verified: `mvn clean verify` green.

*This change was created with AI assistance.*